### PR TITLE
API: Add new endpoint to count by state

### DIFF
--- a/app/controllers/api/groupings_controller.rb
+++ b/app/controllers/api/groupings_controller.rb
@@ -1,18 +1,30 @@
 module Api
-	class GroupingsController < ApplicationController
-	 respond_to :json
+  class GroupingsController < ApplicationController
+    respond_to :json
 
     def count_by_state
       if params[:app_name] && params[:app_env] && params[:language]
         @groupings = Grouping.filtered(params.merge(captured_at: 14.days.ago)).group(:state).count
 
-				respond_to do |format|
-	      	format.json  { render :json => @groupings }
-	    	end
-	    else
-	    	render text: :ko, status: 400 
-	    end
-		end
+        respond_to do |format|
+          format.json { render json: @groupings }
+        end
+      else
+        render text: :ko, status: 400
+      end
+    end
 
-	end
+    def count
+      if params[:app_name] && params[:app_env] && params[:language]
+        @groupings = Grouping.filtered_by_params(params)
+        response = { state: params[:state], count: @groupings.count}
+
+        respond_to do |format|
+          format.json { render json: response }
+        end
+      else
+        render text: :ko, status: 400
+      end
+    end
+  end
 end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -33,6 +33,7 @@ class Grouping < ActiveRecord::Base
 
   scope :open,          -> {where.not(state: :resolved)}
   scope :unacknowledged,        -> {where(state: :unacknowledged)}
+  scope :acknowledged,        -> {where(state: :acknowledged)}
   scope :resolved,      -> {where(state: :resolved)}
   scope :deprioritized,  -> {where(state: :deprioritized)}
   scope :state,         -> (state) {where(state: state)}
@@ -92,10 +93,8 @@ class Grouping < ActiveRecord::Base
   def self.filtered_by_params(filters, opts={})
     search_query = "*"
 
-    opts[:state] ||= :unacknowledged
-
     wheres = {
-        state: opts[:state]
+        state: filters[:state] || opts[:state] || :unacknowledged
     }
     wheres[:app_env]  = filters[:app_env] if filters[:app_env]
     wheres[:app_name] = filters[:app_name] if filters[:app_name]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Wattle::Application.routes.draw do
   namespace :api do 
     resources :groupings do
       get :count_by_state, on: :collection
+      get "/:state/count", on: :collection, to: "groupings#count", constraints: { :state => /[a-zA-Z]+/ }
     end
   end
 

--- a/spec/controllers/api/groupings_controller_spec.rb
+++ b/spec/controllers/api/groupings_controller_spec.rb
@@ -3,35 +3,60 @@ require 'spec_helper'
 describe Api::GroupingsController, type: :controller do
   let(:watcher) { watchers(:default) }
   let(:app_name) { "app1" }
+  let(:scoped_grouping) { Grouping.app_name(app_name).app_env('production').language('ruby') }
 
   before do
     login watcher
   end
 
-  describe "#count_by_state" do 
-    context "with correct params" do 
-      subject { get :count_by_state, format: :json, app_name:app_name, app_env:'production', language:'ruby' }
+  describe "#count_by_state" do
+    context "with correct params" do
+      subject { get :count_by_state, format: :json, app_name: app_name, app_env: 'production', language: 'ruby' }
 
       context "when app with wats" do
         it "return the right count of every groupings state" do
           subject
-          scoped_grouping = Grouping.app_name(app_name).app_env('production').language('ruby')
           expect(response.body).to be_json_eql({ unacknowledged: scoped_grouping.unacknowledged.count, acknowledged: scoped_grouping.state(:acknowledged).count, deprioritized: scoped_grouping.deprioritized.count, resolved: scoped_grouping.resolved.count }.to_json)
         end
       end
     end
     context 'without :app_name params' do
-      subject { get :count_by_state, app_env:'test', language:'ruby',  format: :json }
+      subject { get :count_by_state, app_env: 'test', language: 'ruby', format: :json }
 
       it { is_expected.not_to be_success }
     end
     context 'without :app_env params' do
-      subject { get :count_by_state, app_name:app_name, language:'ruby',  format: :json }
+      subject { get :count_by_state, app_name: app_name, language: 'ruby', format: :json }
 
       it { is_expected.not_to be_success }
     end
     context 'without :language params' do
-      subject { get :count_by_state, app_name:app_name, app_env:'test', format: :json }
+      subject { get :count_by_state, app_name: app_name, app_env: 'test', format: :json }
+
+      it { is_expected.not_to be_success }
+    end
+  end
+
+  describe "#count" do
+    let(:state) { :acknowledged }
+    let(:params) { { format: :json, app_name: app_name, app_env: 'production', language: 'ruby', state: state } }
+
+    it "return the right count of groupings in the acknowledged state" do
+      get :count, params
+      expect(response.body).to be_json_eql({ state: state, count: scoped_grouping.acknowledged.count }.to_json)
+    end
+    context 'without :app_name params' do
+      subject { get :count, params.except(:app_name) }
+
+      it { is_expected.not_to be_success }
+    end
+    context 'without :app_env params' do
+      subject { get :count, params.except(:app_env) }
+
+      it { is_expected.not_to be_success }
+    end
+    context 'without :language params' do
+      subject { get :count, params.except(:language) }
 
       it { is_expected.not_to be_success }
     end


### PR DESCRIPTION
We added a new endpoint so that users can get counts of groupings by state instead of just getting all the counts at once and then having to filter on the other end.